### PR TITLE
[nss-host] Check SFE modules in ECM init script before load

### DIFF
--- a/package/qca/qca-nss-ecm/files/qca-nss-ecm.init
+++ b/package/qca/qca-nss-ecm/files/qca-nss-ecm.init
@@ -1,6 +1,6 @@
 #!/bin/sh  /etc/rc.common
 #
-# Copyright (c) 2014, 2019 The Linux Foundation. All rights reserved.
+# Copyright (c) 2014, 2019-2020 The Linux Foundation. All rights reserved.
 #
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -47,9 +47,19 @@ support_bridge() {
 }
 
 load_sfe() {
-	[ -d /sys/module/shortcut_fe ] || insmod shortcut-fe
-	[ -d /sys/module/shortcut_fe_ipv6 ] || insmod shortcut-fe-ipv6
-	[ -d /sys/module/shortcut_fe_drv ] || insmod shortcut-fe-drv
+	local kernel_version=$(uname -r)
+
+	[ -e "/lib/modules/$kernel_version/shortcut-fe.ko" ] && {
+		[ -d /sys/module/shortcut_fe ] || insmod shortcut-fe
+	}
+
+	[ -e "/lib/modules/$kernel_version/shortcut-fe-ipv6.ko" ] && {
+		[ -d /sys/module/shortcut_fe_ipv6 ] || insmod shortcut-fe-ipv6
+	}
+
+	[ -e "/lib/modules/$kernel_version/shortcut-fe-drv.ko" ] && {
+		[ -d /sys/module/shortcut_fe_drv ] || insmod shortcut-fe-drv
+	}
 }
 
 load_ecm() {
@@ -87,6 +97,13 @@ unload_ecm() {
 }
 
 start() {
+	# If SFE CM is loaded, return.
+	if [ -d /sys/module/shortcut_fe_cm ]; then
+		echo "shortcut_fe CM is loaded, unload it first"
+		echo "cmd: /etc/init.d/shortcut_fe stop"
+		return
+	fi
+
 	load_ecm
 
 	# If the acceleration engine is NSS, enable wifi redirect.
@@ -104,6 +121,11 @@ start() {
 }
 
 stop() {
+	# If ECM is already not loaded, just return.
+	if [ ! -d /sys/module/ecm ]; then
+		return
+	fi
+
 	# If the acceleration engine is NSS, disable wifi redirect.
 	[ -d /sys/kernel/debug/ecm/ecm_nss_ipv4 ] && sysctl -w dev.nss.general.redirect=0
 


### PR DESCRIPTION
If the SFE modules are not present in the modules
directory, do not attemt to load them. Otherwise
it gives errors. These modules are not present in the
5.4 kernel builds.

Signed-off-by: Murat Sezgin msezgin@codeaurora.org
Change-Id: I4b7d2fb532094473a4a03e78a09552c68050f0ef

https://source.codeaurora.org/quic/qsdk/oss/system/feeds/nss-host/log/?h=NHSS.QSDK.11.3.r1
